### PR TITLE
update form mixin, fixes

### DIFF
--- a/src/views/mixins/forms.pug
+++ b/src/views/mixins/forms.pug
@@ -1,7 +1,12 @@
 - const getInputName = (f, property) => `${f.name}[${property}]`
 
 mixin formFor(f, options = {})
-  form(action=_.get(options, 'url') method=_.get(options, 'method', 'get'))
+  - const url = _.get(options, 'url');
+  - const method = _.get(options, 'method', 'get').toLowerCase();
+  - const isStandart = _.includes(['get', 'post'], method);
+  form(action= url method= isStandart ? method : 'post')
+    if !isStandart
+      input(name='_method' type='hidden' value= method)
     block
 
 mixin input(f, property, options = { as: 'text' })


### PR DESCRIPTION
Миксин для формы:
`mixin formFor(f, options = { <url>, <method> })`
Если метод `get || post`, то создается обычная форма;
Если другой метод, то `method="post"`, а `action=<url>?_method=<method>`

index.js
Добавил миддлвару. Без нее `bodyParser` не добавляет в `ctx.request.body` параметры из `ctx.request.query` (необходимо для передачи `_method`)

DEBUG=
в Makefile: `DEBUG="application:*"`, а в logger.js  было `const log = debug('app');`