### PR TITLE
fix class table-striped

### DIFF
--- a/views/users/index.pug
+++ b/views/users/index.pug
@@ -1,7 +1,7 @@
 extends /layouts/application.pug
 
 block content
-  table.table.table-stripped
+  table.table.table-striped
     thead
       tr
         th Full Name


### PR DESCRIPTION
Лишняя "p" в классе, он правильно называется ".table-striped"
https://getbootstrap.com/docs/4.0/content/tables/#striped-rows